### PR TITLE
Allow accessing current localisation via S.current public property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.3'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.10'
+    compile "org.jetbrains.kotlin:kotlin-reflect:1.1.0"
 }
 
 compileKotlin {
@@ -27,7 +28,7 @@ compileTestKotlin {
 patchPluginXml {
     version '1.0.3'
     sinceBuild '181.5540.23'
-    untilBuild '181.*'
+    untilBuild '183.*'
 }
 
 intellij {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.3'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.10'
-    compile "org.jetbrains.kotlin:kotlin-reflect:1.1.0"
 }
 
 compileKotlin {
@@ -28,7 +27,7 @@ compileTestKotlin {
 patchPluginXml {
     version '1.0.3'
     sinceBuild '181.5540.23'
-    untilBuild '183.*'
+    untilBuild '181.*'
 }
 
 intellij {

--- a/src/main/kotlin/eu/long1/flutter/i18n/workers/I18nFileGenerator.kt
+++ b/src/main/kotlin/eu/long1/flutter/i18n/workers/I18nFileGenerator.kt
@@ -142,11 +142,9 @@ class I18nFileGenerator(private val project: Project) {
 
         builder.append(delegateClassResolution)
         map.keys.forEach {
-
-
-            //for hebrew iw=he
+            // for hebrew iw=he.
             if (it.startsWith("iw")) {
-                builder.append("        case \"iw_IL\":\n      case \"he_IL\":\n          S.current = const \$he_IL();\nreturn SynchronousFuture<S>(S.current);\n")
+                builder.append("        case \"iw_IL\":\n        case \"he_IL\":\n          S.current = const \$he_IL();\n          return SynchronousFuture<S>(S.current);\n")
             } else {
                 builder.append("        case \"$it\":\n          S.current = const \$$it();\n          return SynchronousFuture<S>(S.current);\n")
             }

--- a/src/main/kotlin/eu/long1/flutter/i18n/workers/I18nFileGenerator.kt
+++ b/src/main/kotlin/eu/long1/flutter/i18n/workers/I18nFileGenerator.kt
@@ -146,9 +146,9 @@ class I18nFileGenerator(private val project: Project) {
 
             //for hebrew iw=he
             if (it.startsWith("iw")) {
-                builder.append("        case \"iw_IL\":\n      case \"he_IL\":\n          return SynchronousFuture<S>(const \$he_IL());\n")
+                builder.append("        case \"iw_IL\":\n      case \"he_IL\":\n          S.current = const \$he_IL();\nreturn SynchronousFuture<S>(S.current);\n")
             } else {
-                builder.append("        case \"$it\":\n          return SynchronousFuture<S>(const \$$it());\n")
+                builder.append("        case \"$it\":\n          S.current = const \$$it();\n          return SynchronousFuture<S>(S.current);\n")
             }
         }
 
@@ -346,6 +346,8 @@ import 'package:flutter/material.dart';
             """class S implements WidgetsLocalizations {
   const S();
 
+  static S current;
+
   static const GeneratedLocalizationsDelegate delegate =
     GeneratedLocalizationsDelegate();
 
@@ -396,7 +398,8 @@ import 'package:flutter/material.dart';
           // NO-OP.
       }
     }
-    return SynchronousFuture<S>(const S());
+    S.current = const S();
+    return SynchronousFuture<S>(S.current);
   }
 
   @override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,7 +84,7 @@
     </change-notes>
 
 
-    <idea-version since-build="181" until-build="181.*"/>
+    <idea-version since-build="181" until-build="183.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="eu.long1.flutter.i18n.workers.Initializer"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,7 +84,7 @@
     </change-notes>
 
 
-    <idea-version since-build="181" until-build="183.*"/>
+    <idea-version since-build="181" until-build="181.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="eu.long1.flutter.i18n.workers.Initializer"/>


### PR DESCRIPTION
The idea is to create a static property in the auto generated class that would contain the current localised strings so that they can be also accessed outside of flutter build context.

S.current is updated every time S.delegate.load is called so a localised string can now also be accessed as `S.current.myLocalisedString` anywhere in the flutter code.