### PR TITLE
Fix NPE when arb file is empty

### DIFF
--- a/src/main/kotlin/eu/long1/flutter/i18n/uipreview/DialogWrapper.kt
+++ b/src/main/kotlin/eu/long1/flutter/i18n/uipreview/DialogWrapper.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
 import eu.long1.flutter.i18n.files.FileHelpers
@@ -46,7 +47,12 @@ class DialogWrapper(project: Project?, private val panel: JComponent) : com.inte
                     ) {
                         panel.selected.forEach { it ->
                             val langFile = psiManager.findFile(valuesDir.findChild(it)!!)
-                            val json = PsiTreeUtil.getChildOfType(langFile, JsonObject::class.java)
+                            var json = PsiTreeUtil.getChildOfType(langFile, JsonObject::class.java)
+                            if (json == null) {
+                                json = JsonElementGenerator(project).createObject("")
+                                langFile?.add(json as PsiElement);
+                                json = PsiTreeUtil.getChildOfType(langFile, JsonObject::class.java)
+                            }
                             if (json!!.findProperty(panel.resId) == null)
                                 JsonPsiUtil.addProperty(json, property.copy() as JsonProperty, false)
                         }


### PR DESCRIPTION
Sometimes following NPE occurred during intention action dialog "Extract the string resource". PR should prevent null json object.

```
kotlin.KotlinNullPointerException
	at eu.long1.flutter.i18n.uipreview.DialogWrapper$Companion$showAndCreateFile$2$1.run(DialogWrapper.kt:50)
	at com.intellij.openapi.command.WriteCommandAction.lambda$runWriteCommandAction$5(WriteCommandAction.java:363)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl$1.run(WriteCommandAction.java:124)
	at com.intellij.openapi.application.RunResult.run(RunResult.java:35)
	at com.intellij.openapi.command.WriteCommandAction.lambda$null$1(WriteCommandAction.java:264)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1057)
	at com.intellij.openapi.command.WriteCommandAction.lambda$performWriteCommandAction$2(WriteCommandAction.java:263)
	at com.intellij.openapi.command.WriteCommandAction.lambda$doExecuteCommand$4(WriteCommandAction.java:321)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:220)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:188)
	at com.intellij.openapi.command.WriteCommandAction.doExecuteCommand(WriteCommandAction.java:323)
	at com.intellij.openapi.command.WriteCommandAction.performWriteCommandAction(WriteCommandAction.java:262)
	at com.intellij.openapi.command.WriteCommandAction.execute(WriteCommandAction.java:244)
	at com.intellij.openapi.command.WriteCommandAction$BuilderImpl.run(WriteCommandAction.java:126)
	at com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:363)
	at com.intellij.openapi.command.WriteCommandAction.runWriteCommandAction(WriteCommandAction.java:355)
	at eu.long1.flutter.i18n.uipreview.DialogWrapper$Companion$showAndCreateFile$2.run(DialogWrapper.kt:44)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:435)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:419)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:403)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:762)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:732)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:755)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:391)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
